### PR TITLE
Fixed omission of github.com in git clone path

### DIFF
--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -47,7 +47,7 @@ under `GOPATH`:
 [source,shell]
 ----------------------------------------------------------------------
 mkdir -p ${GOPATH}/src/github.com/elastic
-git clone https://github.com/elastic/beats ${GOPATH}/src/elastic/beats
+git clone https://github.com/elastic/beats ${GOPATH}/src/github.com/elastic/beats
 ----------------------------------------------------------------------
 
 To build your beat


### PR DESCRIPTION
Should clone into `${GOPATH}/src/github.com/elastic/beats` as following instructions point to files in that path.